### PR TITLE
build(deps): pre-commit autoupdate

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,6 +34,6 @@ repos:
         files: ^src/
         types: [python]
   - repo: https://github.com/coatl-dev/hadolint-coatl
-    rev: 2.12.0.3
+    rev: 2.12.1b0
     hooks:
       - id: hadolint

--- a/.pylintrc
+++ b/.pylintrc
@@ -302,6 +302,9 @@ max-locals=25
 # Maximum number of parents for a class (see R0901).
 max-parents=7
 
+# Maximum number of positional arguments for function / method.
+max-positional-arguments=25
+
 # Maximum number of public methods for a class (see R0904).
 max-public-methods=60
 


### PR DESCRIPTION
update:
- hadolint-coatl: 2.12.0.3 → 2.12.1b0

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Update the hadolint-coatl pre-commit hook to a new version in the pre-commit configuration.

Build:
- Update the hadolint-coatl pre-commit hook from version 2.12.0.3 to 2.12.1b0 in the .pre-commit-config.yaml file.

<!-- Generated by sourcery-ai[bot]: end summary -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the `hadolint-coatl` repository version for improved Dockerfile linting.
	- Added a new configuration option to limit the maximum number of positional arguments in functions to 25.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->