### PR TITLE
fix(ia): fix AlarmQueryResult method names

### DIFF
--- a/src/com/inductiveautomation/ignition/common/alarming/query/__init__.py
+++ b/src/com/inductiveautomation/ignition/common/alarming/query/__init__.py
@@ -19,11 +19,11 @@ class AlarmQueryResult(object):
     dataset.
     """
 
-    def getAssociatedDate(self, uuid):
+    def getAssociatedData(self, uuid):
         # type: (AnyStr) -> Dataset
         raise NotImplementedError
 
-    def getDataSet(self):
+    def getDataset(self):
         # type: () -> Dataset
         raise NotImplementedError
 
@@ -47,11 +47,11 @@ class AlarmQueryResultImpl(AlarmQueryResult, ArrayList):
         # type: (List[AlarmQueryResult]) -> AlarmQueryResult
         pass
 
-    def getAssociatedDate(self, uuid):
+    def getAssociatedData(self, uuid):
         # type: (AnyStr) -> Dataset
         pass
 
-    def getDataSet(self):
+    def getDataset(self):
         # type: () -> Dataset
         pass
 


### PR DESCRIPTION
there were typos in two methods:
- getAssociatedDate → getAssociatedData
- getDataSet → getDataset

fix: #306

## Summary by Sourcery

Bug Fixes:
- Correct method names in the AlarmQueryResult class by renaming getAssociatedDate to getAssociatedData and getDataSet to getDataset.