### PR TITLE
refactor(ia): add propertyArrayIndices argument to readRawMultiple

### DIFF
--- a/src/ch/qos/logback/classic/__init__.py
+++ b/src/ch/qos/logback/classic/__init__.py
@@ -20,7 +20,7 @@ class Level(Object):
 
     def isGreaterOrEqual(self, r):
         # type: (Level) -> bool
-        pass
+        return True
 
     def toInt(self):
         # type: () -> int

--- a/src/com/google/common/collect/__init__.py
+++ b/src/com/google/common/collect/__init__.py
@@ -49,7 +49,7 @@ class ImmutableList(ImmutableCollection):
 
     def contains(self, o):
         # type: (Object) -> bool
-        pass
+        return True
 
     @staticmethod
     def copyOf(*args):
@@ -106,7 +106,7 @@ class ImmutableSet(ImmutableCollection):
 
     def contains(self, o):
         # type: (Object) -> bool
-        pass
+        return True
 
     @staticmethod
     def copyOf(*args):

--- a/src/com/inductiveautomation/ignition/client/util/gui/scheduling/__init__.py
+++ b/src/com/inductiveautomation/ignition/client/util/gui/scheduling/__init__.py
@@ -38,7 +38,7 @@ class ScheduleModel(DefaultBindableModel):
 
     def isDaySelected(self, day):
         # type: (ScheduleModel.DayOfWeek) -> bool
-        pass
+        return True
 
     def isEveryHourEnabled(self):
         # type: () -> bool

--- a/src/com/inductiveautomation/ignition/common/__init__.py
+++ b/src/com/inductiveautomation/ignition/common/__init__.py
@@ -35,6 +35,22 @@ class Dataset(object):
 
     def binarySearch(self, column, key):
         # type: (int, Any) -> int
+        """Performs a binary search on the specified column, looking for
+        the specified key.
+
+        Args:
+            column: The column to search in.
+            key: The key to search for.
+
+        Returns:
+            The index of the key in the column, or a negative number if
+            the key is not found.
+
+        Raises:
+            ClassCastException: If the column is not Comparable.
+            UnsupportedOperationException: If the Dataset implementation
+                declines to implement this operation.
+        """
         pass
 
     def getColumnAsList(self, col):
@@ -55,6 +71,9 @@ class Dataset(object):
 
         Returns:
             The number of columns in the dataset.
+
+        Raises:
+            NotImplementedError: If the method is not implemented.
         """
         raise NotImplementedError
 
@@ -67,6 +86,9 @@ class Dataset(object):
 
         Returns:
             The index of the column with the name colName.
+
+        Raises:
+            NotImplementedError: If the method is not implemented.
         """
         raise NotImplementedError
 
@@ -79,6 +101,9 @@ class Dataset(object):
 
         Returns:
             The name of the column at the index colIndex.
+
+        Raises:
+            NotImplementedError: If the method is not implemented.
         """
         raise NotImplementedError
 
@@ -88,6 +113,9 @@ class Dataset(object):
 
         Returns:
             A list with the names of all the columns.
+
+        Raises:
+            NotImplementedError: If the method is not implemented.
         """
         raise NotImplementedError
 
@@ -100,6 +128,9 @@ class Dataset(object):
 
         Returns:
             The type of the column at the index.
+
+        Raises:
+            NotImplementedError: If the method is not implemented.
         """
         raise NotImplementedError
 
@@ -109,6 +140,9 @@ class Dataset(object):
 
         Returns:
             A list with the types of all the columns.
+
+        Raises:
+            NotImplementedError: If the method is not implemented.
         """
         raise NotImplementedError
 
@@ -121,11 +155,12 @@ class Dataset(object):
             row: The row index. Zero-based index.
             col: The column index. Zero-based index.
 
+        Returns:
+            If the given column is a numeric type or a Date, then
+                the value will be returned as a double.
+
         Raises:
-            IllegalArgumentException: if the value at row, col is not a
-                number or Date.
-            UnsupportedOperationException: If the Dataset implementation
-                declines to implement this operation.
+            NotImplementedError: If the method is not implemented.
         """
         raise NotImplementedError
 
@@ -137,9 +172,11 @@ class Dataset(object):
             row: The row index. Zero-based index.
             col: The column index. Zero-based index.
 
+        Returns:
+            The quality of the value at the given location.
+
         Raises:
-            ArrayIndexOutOfBoundsException: If the given row, col is out
-                of range and hasQualityData() returns true.
+            NotImplementedError: If the method is not implemented.
         """
         raise NotImplementedError
 
@@ -149,6 +186,9 @@ class Dataset(object):
 
         Returns:
             The number of rows in the dataset.
+
+        Raises:
+            NotImplementedError: If the method is not implemented.
         """
         raise NotImplementedError
 
@@ -163,6 +203,9 @@ class Dataset(object):
 
         Returns:
             The value found at the row and column.
+
+        Raises:
+            NotImplementedError: If the method is not implemented.
         """
         raise NotImplementedError
 
@@ -274,6 +317,10 @@ class AbstractDataset(Dataset):
             row: The row index. Zero-based index.
             col: The column index. Zero-based index.
 
+        Returns:
+            If the given column is a numeric type or a Date, then
+                the value will be returned as a double.
+
         Raises:
             IllegalArgumentException: if the value at row, col is not a
                 number or Date.
@@ -289,6 +336,9 @@ class AbstractDataset(Dataset):
         Args:
             row: The row index. Zero-based index.
             col: The column index. Zero-based index.
+
+        Returns:
+            The quality of the value at the given location.
 
         Raises:
             ArrayIndexOutOfBoundsException: If the given row, col is out
@@ -501,12 +551,12 @@ class StringPath(Object, Path, Comparable):
 
     def isAncestorOf(self, path):
         # type: (Path) -> bool
-        pass
+        return True
 
     @staticmethod
     def isRelative(path):
         # type: (StringPath) -> bool
-        pass
+        return True
 
     def isRoot(self):
         # type: () -> bool
@@ -538,7 +588,7 @@ class StringPath(Object, Path, Comparable):
 
         def isAncestorOf(self, child):
             # type: (Path) -> bool
-            pass
+            return True
 
 
 class TypeUtilities(Object):

--- a/src/com/inductiveautomation/ignition/common/alarming/__init__.py
+++ b/src/com/inductiveautomation/ignition/common/alarming/__init__.py
@@ -226,7 +226,7 @@ class PyAlarmEventImpl(PyAlarmEvent, PyObject):
 
     def contains(self, property):
         # type: (AnyStr) -> bool
-        pass
+        return True
 
     def get(self, property):
         # type: (AnyStr) -> Object

--- a/src/com/inductiveautomation/ignition/common/browsing/__init__.py
+++ b/src/com/inductiveautomation/ignition/common/browsing/__init__.py
@@ -44,11 +44,11 @@ class BrowseFilter(Object):
 
     def checkNameFilters(self, path):
         # type: (Any) -> bool
-        pass
+        return True
 
     def checkProperties(self, toCheck):
         # type: (PropertyValueSource) -> bool
-        pass
+        return True
 
     def getAllowedTypes(self):
         # type: () -> Iterable[AnyStr]
@@ -157,7 +157,7 @@ class BrowseFilter(Object):
 
         def passes(self, value):
             # type: (AnyStr) -> bool
-            pass
+            return True
 
 
 class Results(Object):

--- a/src/com/inductiveautomation/ignition/common/licensing/__init__.py
+++ b/src/com/inductiveautomation/ignition/common/licensing/__init__.py
@@ -16,7 +16,7 @@ from java.util import Date
 class LicenseDetails(object):
     def checkFlag(self, key):
         # type: (AnyStr) -> bool
-        pass
+        return True
 
     def getExpirationDate(self):
         # type: () -> Date

--- a/src/com/inductiveautomation/ignition/common/modules/__init__.py
+++ b/src/com/inductiveautomation/ignition/common/modules/__init__.py
@@ -253,11 +253,11 @@ class ModuleInfo(Object):
 
         def isRequiredArchitecture(self, arch):
             # type: (Platform.Architecture) -> bool
-            pass
+            return True
 
         def isRequiredOS(self, os):
             # type: (Platform.OperatingSystem) -> bool
-            pass
+            return True
 
     class LibraryInfo(Object):
         def getName(self):

--- a/src/com/inductiveautomation/ignition/common/project/resource/__init__.py
+++ b/src/com/inductiveautomation/ignition/common/project/resource/__init__.py
@@ -301,11 +301,11 @@ class ResourcePath(Object, Comparable):
 
     def isAncestorOf(self, possibleDescendant):
         # type: (ResourcePath) -> bool
-        pass
+        return True
 
     def isParentOf(self, possibleChild):
         # type: (ResourcePath) -> bool
-        pass
+        return True
 
     def isResourceTypeFolder(self):
         # type: () -> bool
@@ -368,7 +368,7 @@ class ResourceType(Object):
 
     def matches(self, op):
         # type: (Any) -> bool
-        pass
+        return True
 
     def rootPath(self):
         # type: () -> ResourcePath

--- a/src/com/inductiveautomation/ignition/common/script/builtin/__init__.py
+++ b/src/com/inductiveautomation/ignition/common/script/builtin/__init__.py
@@ -281,6 +281,10 @@ class DatasetUtilities(Object):
 
             Returns:
                 The index of the column with the name colName.
+
+            Raises:
+                ArrayIndexOutOfBoundsException: If the column isn't
+                    found.
             """
             pass
 
@@ -293,6 +297,10 @@ class DatasetUtilities(Object):
 
             Returns:
                 The name of the column at the index colIndex.
+
+            Raises:
+                ArrayIndexOutOfBoundsException: If the given index is
+                    out of range.
             """
             pass
 
@@ -314,12 +322,17 @@ class DatasetUtilities(Object):
 
             Returns:
                 The type of the column at the index.
+
+            Raises:
+                ArrayIndexOutOfBoundsException: If the given index is
+                    out of range.
             """
             pass
 
         def getColumnTypes(self):
             # type: () -> List[Class]
-            """Returns a list with the types of all the columns.
+            """Returns an unmodifiable list of this dataset's column
+            types, in order.
 
             Returns:
                 A list with the types of all the columns.
@@ -334,6 +347,10 @@ class DatasetUtilities(Object):
             Args:
                 row: The row index. Zero-based index.
                 col: The column index. Zero-based index.
+
+            Returns:
+                If the given column is a numeric type or a Date, then
+                    the value will be returned as a double.
 
             Raises:
                 IllegalArgumentException: if the value at row, col is
@@ -350,6 +367,9 @@ class DatasetUtilities(Object):
             Args:
                 row: The row index. Zero-based index.
                 col: The column index. Zero-based index.
+
+            Returns:
+                The quality of the value at the given location.
 
             Raises:
                 ArrayIndexOutOfBoundsException: If the given row, col is
@@ -377,8 +397,13 @@ class DatasetUtilities(Object):
 
             Returns:
                 The value found at the row and column.
+
+            Raises:
+                ArrayIndexOutOfBoundsException: If the column isn't
+                    found.
             """
-            pass
+            print(row, col)
+            return True
 
         def setData(self, data):
             # type: (Dataset) -> None

--- a/src/com/inductiveautomation/ignition/common/util/__init__.py
+++ b/src/com/inductiveautomation/ignition/common/util/__init__.py
@@ -269,7 +269,7 @@ class TimelineList(Object):
 
     def covered(self, time):
         # type: (long) -> bool
-        pass
+        return True
 
     def get(self, time):
         # type: (long) -> Any
@@ -293,7 +293,7 @@ class TimelineList(Object):
 
     def nextEvent(self, time, allowRollover=None):
         # type: (long, Optional[bool]) -> bool
-        pass
+        return True
 
     def size(self):
         # type: () -> int
@@ -315,11 +315,11 @@ class TimelineList(Object):
 
         def contains(self, time):
             # type: (long) -> bool
-            pass
+            return True
 
         def endsBefore(self, time):
             # type: (long) -> bool
-            pass
+            return True
 
         def getDuration(self):
             # type: () -> long

--- a/src/com/inductiveautomation/ignition/common/xmlserialization/serialization/__init__.py
+++ b/src/com/inductiveautomation/ignition/common/xmlserialization/serialization/__init__.py
@@ -117,7 +117,7 @@ class XMLSerializationContext(Object):
 
     def safeEquals(self, foo, bar):
         # type: (Object, Object) -> bool
-        pass
+        return True
 
     def serialize(self, obj):
         # type: (Object) -> Element

--- a/src/com/inductiveautomation/ignition/gateway/project/__init__.py
+++ b/src/com/inductiveautomation/ignition/gateway/project/__init__.py
@@ -20,7 +20,7 @@ class ResourceFilter(Object):
 
     def apply(self, arg):
         # type: (Union[ProjectResource, ProjectResourceId]) -> bool
-        pass
+        return True
 
     @staticmethod
     def forScope(applicationScope):

--- a/src/java/lang/__init__.py
+++ b/src/java/lang/__init__.py
@@ -6,13 +6,16 @@ from __future__ import print_function
 
 __all__ = [
     "Appendable",
+    "ArrayIndexOutOfBoundsException",
     "AutoCloseable",
     "CharSequence",
     "Class",
+    "ClassCastException",
     "Comparable",
     "Enum",
     "Exception",
     "IllegalArgumentException",
+    "IndexOutOfBoundsException",
     "NullPointerException",
     "Number",
     "Object",
@@ -25,6 +28,7 @@ __all__ = [
     "StringBuilder",
     "Thread",
     "Throwable",
+    "UnsupportedOperationException",
 ]
 
 import __builtin__ as builtins
@@ -307,11 +311,11 @@ class String(unicode):
 
     def contains(self, arg):
         # type: (String) -> bool
-        pass
+        return True
 
     def contentEquals(self, arg):
         # type: (Union[CharSequence, StringBuffer]) -> bool
-        pass
+        return True
 
     @staticmethod
     def copyValueOf(*args):
@@ -324,11 +328,11 @@ class String(unicode):
 
     def equals(self, anObject):
         # type: (Object) -> bool
-        pass
+        return True
 
     def equalsIgnoreCase(self, anotherString):
         # type: (String) -> bool
-        pass
+        return True
 
     def getBytes(self, *args):
         # type: (*Any) -> Optional[object]
@@ -376,7 +380,7 @@ class String(unicode):
 
     def matches(self, regex):
         # type: (String) -> bool
-        pass
+        return True
 
     def notify(self):
         # type: () -> None
@@ -392,7 +396,7 @@ class String(unicode):
 
     def regionMatches(self, *args):
         # type: (*Any) -> bool
-        pass
+        return True
 
     def repeat(self, count):
         # type: (int) -> String
@@ -755,6 +759,16 @@ class RuntimeException(Exception):
         super(RuntimeException, self).__init__(message, cause)
 
 
+class ClassCastException(RuntimeException):
+    """Thrown to indicate that the code has attempted to cast an object
+    to a subclass of which it is not an instance.
+    """
+
+    def __init__(self, s=None):
+        # type: (Optional[AnyStr]) -> None
+        super(ClassCastException, self).__init__(s)
+
+
 class IllegalArgumentException(RuntimeException):
     """Thrown to indicate that a method has been passed an illegal or
     inappropriate argument.
@@ -765,6 +779,29 @@ class IllegalArgumentException(RuntimeException):
         super(IllegalArgumentException, self).__init__(message, cause)
 
 
+class IndexOutOfBoundsException(RuntimeException):
+    """Thrown to indicate that an index of some sort (such as to an
+    array, to a string, or to a vector) is out of range.
+    """
+
+    def __init__(self, arg=None):
+        # type: (Optional[Union[int, AnyStr]]) -> None
+        super(IndexOutOfBoundsException, self).__init__()
+
+
+class ArrayIndexOutOfBoundsException(IndexOutOfBoundsException):
+    """Thrown to indicate that an array has been accessed with an
+    illegal index.
+
+    The index is either negative or greater than or equal to the size of
+    the array.
+    """
+
+    def __init__(self, arg=None):
+        # type: (Optional[Union[int, AnyStr]]) -> None
+        super(ArrayIndexOutOfBoundsException, self).__init__(arg)
+
+
 class NullPointerException(RuntimeException):
     """Thrown when an application attempts to use null in a case where
     an object is required.
@@ -773,6 +810,16 @@ class NullPointerException(RuntimeException):
     def __init__(self, message=None, cause=None):
         # type: (Optional[str], Optional[Throwable]) -> None
         super(NullPointerException, self).__init__(message, cause)
+
+
+class UnsupportedOperationException(RuntimeException):
+    """Thrown to indicate that the requested operation is not
+    supported.
+    """
+
+    def __init__(self, message=None, cause=None):
+        # type: (Optional[str], Optional[Throwable]) -> None
+        super(UnsupportedOperationException, self).__init__(message, cause)
 
 
 class Thread(Object):

--- a/src/java/lang/__init__.py
+++ b/src/java/lang/__init__.py
@@ -765,7 +765,7 @@ class ClassCastException(RuntimeException):
     """
 
     def __init__(self, s=None):
-        # type: (Optional[AnyStr]) -> None
+        # type: (Optional[str]) -> None
         super(ClassCastException, self).__init__(s)
 
 

--- a/src/java/util/__init__.py
+++ b/src/java/util/__init__.py
@@ -114,7 +114,7 @@ class Collection(object):
 
     def removeIf(self, filter):
         # type: (Predicate) -> bool
-        pass
+        return True
 
     def retainAll(self, v):
         # type: (Collection) -> bool
@@ -533,12 +533,12 @@ class Arrays(Object):
     @staticmethod
     def deepEquals(a1, a2):
         # type: (List[Object], List[Object]) -> bool
-        pass
+        return True
 
     @staticmethod
     def equals(*args, **kwargs):
         # type: (*Any, **Any) -> bool
-        pass
+        return True
 
     @staticmethod
     def fill(a, *args):
@@ -593,11 +593,11 @@ class Arrays(Object):
 class AbstractCollection(Object, Collection):
     def add(self, e):
         # type: (Any) -> bool
-        pass
+        return True
 
     def addAll(self, c):
         # type: (Collection) -> bool
-        pass
+        return True
 
     def clear(self):
         # type: () -> None
@@ -605,11 +605,11 @@ class AbstractCollection(Object, Collection):
 
     def contains(self, o):
         # type: (Object) -> bool
-        pass
+        return True
 
     def containsAll(self, c):
         # type: (Collection) -> bool
-        pass
+        return True
 
     def isEmpty(self):
         # type: () -> bool
@@ -621,15 +621,15 @@ class AbstractCollection(Object, Collection):
 
     def remove(self, o):
         # type: (Object) -> bool
-        pass
+        return True
 
     def removeAll(self, c):
         # type: (Collection) -> bool
-        pass
+        return True
 
     def retainAll(self, v):
         # type: (Collection) -> bool
-        pass
+        return True
 
     def size(self):
         # type: () -> int
@@ -665,11 +665,11 @@ class AbstractMap(Object, Map):
 
     def containsKey(self, key):
         # type: (Object) -> bool
-        pass
+        return True
 
     def containsValue(self, value):
         # type: (Object) -> bool
-        pass
+        return True
 
     def entrySet(self):
         # type: () -> Set[Map.Entry]
@@ -1084,15 +1084,15 @@ class Hashtable(Dictionary, Map):
 
     def contains(self, value):
         # type: (Object) -> bool
-        pass
+        return True
 
     def containsKey(self, key):
         # type: (Object) -> bool
-        pass
+        return True
 
     def containsValue(self, value):
         # type: (Object) -> bool
-        pass
+        return True
 
     def elements(self):
         # type: () -> Enumeration

--- a/src/org/apache/log4j/__init__.py
+++ b/src/org/apache/log4j/__init__.py
@@ -145,7 +145,7 @@ class Priority(Object):
 
     def isGreaterOrEqual(self, r):
         # type: (Priority) -> bool
-        pass
+        return True
 
     def toInt(self):
         # type: () -> int

--- a/src/org/bson/__init__.py
+++ b/src/org/bson/__init__.py
@@ -74,11 +74,11 @@ class Document(Object):
 
     def containsKey(self, key):
         # type: (Object) -> bool
-        pass
+        return True
 
     def containsValue(self, value):
         # type: (Object) -> bool
-        pass
+        return True
 
     def entrySet(self):
         # type: () -> Set[Any]
@@ -90,7 +90,7 @@ class Document(Object):
 
     def getBoolean(self, *args):
         # type: (*Any) -> bool
-        pass
+        return True
 
     def getDate(self, key):
         # type: (Object) -> Date

--- a/src/org/bson/types/__init__.py
+++ b/src/org/bson/types/__init__.py
@@ -205,7 +205,7 @@ class ObjectId(Object):
     @staticmethod
     def isValid(hexString):
         # type: (AnyStr) -> bool
-        pass
+        return True
 
     def putToByteBuffer(self, buffer):
         # type: (ByteBuffer) -> None

--- a/src/system/bacnet/__init__.py
+++ b/src/system/bacnet/__init__.py
@@ -31,7 +31,7 @@ def readRaw(
     propertyId,  # type: PropertyIdentifier
     propertyArrayIndex=None,  # type: Optional[int]
 ):
-    # type: (...) -> List[Any]
+    # type: (...) -> Any
     """Read from any BACnet object not explicitly supported by the
     BACnet driver.
 
@@ -47,9 +47,11 @@ def readRaw(
             from. This parameter is optional and should not be used when
             reading from the entire array or if the property is not an
             array.
+
+    Returns:
+        An Encodable object corresponding to the property being read.
     """
     print(deviceName, objectType, objectId, propertyId, propertyArrayIndex)
-    return [0]
 
 
 def readRawMultiple(
@@ -57,26 +59,33 @@ def readRawMultiple(
     objectTypes,  # type: List[ObjectType]
     objectIds,  # type: List[int]
     propertyIds,  # type: List[PropertyIdentifier]
+    propertyArrayIndices=None,  # type: Optional[List[int]]
 ):
     # type: (...) -> List[Any]
-    """This function is the bulk version of system.bacnet.readRaw to
-    allow multiple object/property combinations to be read
-    simultaneously from a single request.
+    """This function is the bulk version of system.bacnet.readRaw. Reads
+    properties from objects and returns a list of corresponding
+    Encodable objects provided equal-length lists of object types,
+    object instance numbers, property ids, and property array indices.
 
     Args:
         deviceName: The name of the configured BACnet/IP device instance
             to read from.
-        objectTypes: The numeric ids of the objectType of the object
-            instances being read from.
-        objectIds: The object instance number to read.
-        propertyIds: The PropertyIdentifier of the object instance being
-            read.
+        objectTypes: A list of ObjectType(s) for the object instance
+            being read.
+        objectIds: A list of object instance numbers to read.
+        propertyIds: A list of PropertyIdentifier(s) for the object
+            instances being read.
+        propertyArrayIndices: An optional list of array indices
+            corresponding to array properties being read. None should be
+            specified as an element when reading from the entire array
+            property or if the property is not an array. Defaults to a
+            list of None when this parameter is omitted.
 
     Returns:
         A list of Encodable objects corresponding to the properties
         being read.
     """
-    print(deviceName, objectTypes, objectIds, propertyIds)
+    print(deviceName, objectTypes, objectIds, propertyIds, propertyArrayIndices)
     return []
 
 

--- a/src/system/dataset.py
+++ b/src/system/dataset.py
@@ -551,7 +551,7 @@ def toDataSet(*args):
     2) system.dataset.toDataSet(headers, data)
 
     Args:
-        args: A variable-length argument list.
+        *args: A variable-length argument list.
 
     Returns:
         The newly created dataset.

--- a/src/system/db.py
+++ b/src/system/db.py
@@ -520,6 +520,7 @@ def runNamedQuery(*args, **kwargs):
         the datatype of the value returned by a Scalar Query.
     """
     print(args, kwargs)
+    return True
 
 
 def runPrepQuery(
@@ -672,7 +673,7 @@ def runSFNamedQuery(*args, **kwargs):
     system.db.runSFNamedQuery(project, path, params)
 
     Args:
-        *args : Variable length argument list.
+        *args: Variable length argument list.
         **kwargs: Arbitrary keyword arguments.
 
     Returns:
@@ -758,6 +759,7 @@ def runScalarPrepQuery(
          Returns None if no rows were returned.
     """
     print(query, args, database, tx)
+    return 42
 
 
 def runScalarQuery(query, database="", tx=None):
@@ -782,6 +784,7 @@ def runScalarQuery(query, database="", tx=None):
          Returns None if no rows were returned.
     """
     print(query, database, tx)
+    return 42
 
 
 def runUpdateQuery(

--- a/src/system/gui.py
+++ b/src/system/gui.py
@@ -117,7 +117,7 @@ def color(*args):
     having the RGB[A] channels specified explicitly.
 
     Args:
-        args: Variable-length argument list.
+        *args: Variable length argument list.
 
     Returns:
         The newly created color.
@@ -310,7 +310,7 @@ def getParentWindow(event):
     an event, returning a reference to it.
 
     Args:
-        A component event object.
+        event: A component event object.
 
     Returns:
         The window that contains the component that fired the event.

--- a/src/system/math.py
+++ b/src/system/math.py
@@ -269,6 +269,9 @@ def percentile(values, percentile):
     Returns:
         An estimate of the requested percentile of the input, or NaN if
         the input was empty or null.
+
+    Raises:
+        ValueError: If the percentile is out of bounds.
     """
     print(values, percentile)
     if 0 > percentile > 100:

--- a/src/system/util.py
+++ b/src/system/util.py
@@ -76,7 +76,7 @@ from com.inductiveautomation.ignition.common.script.builtin import (
 from com.inductiveautomation.ignition.common.util import LoggerEx
 from dev.coatl.helper.types import AnyStr
 from java.awt import Toolkit
-from java.lang import Thread
+from java.lang import IllegalArgumentException, Thread
 from java.util import Date, Locale
 
 APPLET_FLAG = 16
@@ -859,6 +859,7 @@ def sendRequest(
         remoteServer,
         timeoutSec,
     )
+    return ""
 
 
 def sendRequestAsync(
@@ -966,6 +967,8 @@ def setLocale(locale):
     Raises:
         IllegalArgumentException: If passed an invalid local code.
     """
+    if not locale:
+        raise IllegalArgumentException("Invalid locale code")
     print(locale)
 
 


### PR DESCRIPTION
style:
- fix docstrings
- add raise keyword
- add return values

## Summary by Sourcery

Add support for reading specific elements from array properties in BACnet objects.

New Features:
- Added a new `propertyArrayIndices` argument to `system.bacnet.readRawMultiple` to specify indices of array elements to read.

Tests:
- Updated return types of some functions in the `system.bacnet` module.