### PR TITLE
ci: set path input for pylint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,3 +16,5 @@ jobs:
   pylint:
     needs: pre-commit
     uses: coatl-dev/workflows/.github/workflows/pylint.yml@v4
+    with:
+      path: src

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,6 +14,8 @@ jobs:
   pylint:
     needs: pre-commit
     uses: coatl-dev/workflows/.github/workflows/pylint.yml@v4
+    with:
+      path: src
 
   tox:
     needs:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,4 +39,5 @@ repos:
         name: pylint
         entry: pylint
         language: system
+        files: ^src/
         types: [python]


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Set the "path" input for the pylint workflow to "src".