### PR TITLE
ci(pip-compile-upgrade): use blacksmith

### DIFF
--- a/.github/workflows/pip-compile-upgrade.yml
+++ b/.github/workflows/pip-compile-upgrade.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   pip-compile-upgrade:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Switch pip-compile-upgrade job to run on blacksmith-2vcpu-ubuntu-2404 instead of ubuntu-latest