### PR TITLE
ci: use coatl-dev/workflows@v6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   pylint:
-    uses: coatl-dev/workflows/.github/workflows/pylint.yml@v5
+    uses: coatl-dev/workflows/.github/workflows/pylint.yml@v6
     with:
       path: src
       working-directory: ignition-api

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -18,12 +18,12 @@ on:
 
 jobs:
   tox-ignition-api:
-    uses: coatl-dev/workflows/.github/workflows/tox-docker.yml@v5
+    uses: coatl-dev/workflows/.github/workflows/tox-docker.yml@v6
     with:
       working-directory: ignition-api
 
   tox-ignition-api-stubs:
-    uses: coatl-dev/workflows/.github/workflows/tox.yml@v5
+    uses: coatl-dev/workflows/.github/workflows/tox.yml@v6
     with:
       python-versions: |
         3.9

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,16 +15,15 @@ jobs:
 
   publish-ignition-api:
     needs: pr-build
-    uses: coatl-dev/workflows/.github/workflows/pypi-upload.yml@v5
+    uses: coatl-dev/workflows/.github/workflows/pypi-upload.yml@v6
     with:
-      python-version: '2.7'
       working-directory: ignition-api
     secrets:
       password: ${{ secrets.PYPI_API_TOKEN_IGNITION_API_PKG }}
 
   publish-ignition-api-stubs:
     needs: pr-build
-    uses: coatl-dev/workflows/.github/workflows/pypi-upload.yml@v5
+    uses: coatl-dev/workflows/.github/workflows/pypi-upload.yml@v6
     with:
       python-version: '3.12'
       working-directory: ignition-api-stubs


### PR DESCRIPTION
## Summary by Sourcery

Update GitHub Actions templates to use coatl-dev/workflows@v6 across linting, testing, and publishing pipelines

CI:
- Bump pylint, tox, tox-docker, and PyPI upload workflow references from v5 to v6
- Remove explicit Python 2.7 version specification from the ignition-api publish job