### PR TITLE
build: simplify file exclude pattern for pydocstyle hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -64,7 +64,7 @@ repos:
     hooks:
       - id: pydocstyle
         files: ^ignition-api/src/
-        exclude: ^(ignition-api/src/ch/|ignition-api/src/com/|ignition-api/src/dev/|ignition-api/src/java/|ignition-api/src/javax/|ignition-api/src/org/)
+        exclude: ^ignition-api/src/(ch|com|dev|java|javax|org)/
         args: [--config=ignition-api/.pydocstyle]
   - repo: https://github.com/jsh9/pydoclint
     rev: 0.6.7

--- a/ignition-api-stubs/README.md
+++ b/ignition-api-stubs/README.md
@@ -57,10 +57,10 @@ See [CODE_OF_CONDUCT.md].
 
 <!-- Links -->
 [CODE_OF_CONDUCT.md]: https://github.com/ignition-devs/.github/blob/main/CODE_OF_CONDUCT.md
-[CONTRIBUTING.md]: ../CONTRIBUTING.md
+[CONTRIBUTING.md]: https://github.com/ignition-devs/ignition-api-8.1/blob/main/CONTRIBUTING.md
 [contributors]: https://github.com/ignition-devs/ignition-api-8.1-stubs/graphs/contributors
 [Discussions]: https://github.com/orgs/ignition-devs/discussions
 [`ignition-api-8.1`]: https://github.com/ignition-devs/ignition-api-8.1
-[LICENSE]: ../LICENSE
-[`stubgen`]: https://mypy.readthedocs.io/en/stable/stubgen.html
+[LICENSE]: https://github.com/ignition-devs/ignition-api-8.1/blob/main/LICENSE
+[`stubgen`]: https://coatl-mypy.readthedocs.io/en/v0.971/stubgen.html
 [stubs]: https://www.python.org/dev/peps/pep-484/

--- a/ignition-api/README.md
+++ b/ignition-api/README.md
@@ -188,11 +188,11 @@ See the [LICENSE].
 This project has adopted the [Microsoft Open Source Code of Conduct].
 
 <!-- Links -->
-[CONTRIBUTING.md]: ../CONTRIBUTING.md#contributing-to-ignition-api
+[CONTRIBUTING.md]: https://github.com/ignition-devs/ignition-api-8.1/blob/main/CONTRIBUTING.md#contributing-to-ignition-api
 [CONTRIBUTORS]: https://github.com/ignition-devs/ignition-api-8.1/graphs/contributors
 [Discussions]: https://github.com/orgs/ignition-devs/discussions
 [Ignition System Functions]: https://docs.inductiveautomation.com/docs/8.1/appendix/scripting-functions
-[LICENSE]: ../LICENSE
+[LICENSE]: https://github.com/ignition-devs/ignition-api-8.1/blob/main/LICENSE
 [Microsoft Open Source Code of Conduct]: https://opensource.microsoft.com/codeofconduct/
 [Python 2.7.18]: https://www.python.org/downloads/release/python-2718/
 [releases]: https://github.com/ignition-devs/ignition-api-8.1/releases


### PR DESCRIPTION
use full path for contributing guidelines and license

## Summary by Sourcery

Use full GitHub URLs for contributing guidelines, license references, and the stubgen documentation in README files, and simplify the pydocstyle exclude pattern in the pre-commit configuration.

CI:
- Simplify the pydocstyle hook’s file exclude pattern in .pre-commit-config.yaml using a grouped regex.

Documentation:
- Replace relative CONTRIBUTING.md and LICENSE links in README files with full GitHub URLs and update the stubgen documentation link.