### PR TITLE
 build(deps): bump unimport from 1.2.1 to 1.3.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,10 +19,10 @@ repos:
     hooks:
       - id: black
   - repo: https://github.com/hakancelikdev/unimport
-    rev: 1.2.1
+    rev: 1.3.0
     hooks:
       - id: unimport
-        language_version: python3.12
+        files: ^ignition-api/src/
   - repo: https://github.com/PyCQA/isort
     rev: 6.0.1
     hooks:


### PR DESCRIPTION
- remove the language_version key now unimport is compatible with 3.13
- add files key

## Summary by Sourcery

Upgrade the unimport pre-commit hook to version 1.3.0 and adjust its configuration

Enhancements:
- Remove the explicit language_version since unimport now supports Python 3.13
- Restrict the unimport hook to files under ignition-api/src using the files key

Build:
- Bump unimport version from 1.2.1 to 1.3.0 in .pre-commit-config.yaml