### PR TITLE
build(deps): add pydoclint as dependency for flake8 hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 ci:
   autoupdate_commit_msg: 'build(deps): pre-commit autoupdate'
-  autofix_commit_msg: 'chore: apply auto fixes with pre-commit'
+  autofix_commit_msg: 'stylw: apply auto fixes with pre-commit'
   skip:
     - pylint
 
@@ -52,6 +52,7 @@ repos:
         name: flake8-ignition-api
         files: ^ignition-api/src/
         args: [--config, ignition-api/tox.ini]
+        additional_dependencies: [pydoclint]
   - repo: https://github.com/PyCQA/flake8
     rev: 7.3.0
     hooks:
@@ -68,12 +69,6 @@ repos:
         files: ^ignition-api/src/
         exclude: ^ignition-api/src/(ch|com|dev|java|javax|org)/
         args: [--config, ignition-api/tox.ini]
-  - repo: https://github.com/jsh9/pydoclint
-    rev: 0.6.7
-    hooks:
-      - id: pydoclint-flake8
-        files: ^ignition-api/src/
-        args: [--config=ignition-api/tox.ini, --extend-ignore=F401]
   - repo: https://github.com/commitizen-tools/commitizen
     rev: v4.8.3
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 ci:
   autoupdate_commit_msg: 'build(deps): pre-commit autoupdate'
-  autofix_commit_msg: 'stylw: apply auto fixes with pre-commit'
+  autofix_commit_msg: 'style: apply auto fixes with pre-commit'
   skip:
     - pylint
 

--- a/ignition-api/tox.ini
+++ b/ignition-api/tox.ini
@@ -32,28 +32,33 @@ commands =
 
 [testenv:style]
 description = apply style
+base_python = python3.12
 skip_install = true
 deps =
     black
     docformatter
     flake8==5.0.4
     isort
+    pydoclint
     pydocstyle
     sort-all
+    unimport
 commands =
-    bash -c 'sort-all $(find src -name "*.py" -type f)'
+    python -c \
+      "import pathlib, subprocess; \
+      files = [str(p) for p in pathlib.Path('src').rglob('*.py')]; \
+      subprocess.run(['sort-all'] + files, check=True)"
     black --quiet src
-    isort src
+    unimport src
+    isort --settings-file=tox.ini src
     docformatter \
       --in-place \
       --wrap-summaries 72 \
       --close-quotes-on-newline \
       --recursive \
       src
-    flake8 src
-    pydocstyle src
-allowlist_externals =
-    bash
+    flake8 --select=DOC --config=tox.ini src
+    pydocstyle --config=tox.ini src{/}system
 
 [type]
 base_python = python3.12
@@ -66,10 +71,15 @@ wrap-summaries = 72
 close-quotes-on-newline = true
 
 [flake8]
-ignore = E741, F821
+ignore = DOC202, E741, F821
 max-complexity = 10
 max-doc-length = 72
 max-line-length = 120
+# pydoclint
+style = google
+arg-type-hints-in-docstring = False
+arg-type-hints-in-signature = False
+check-return-types = False
 
 [isort]
 extra_standard_library = typing


### PR DESCRIPTION
update config for flake8

## Summary by Sourcery

Integrate pydoclint into style checks and streamline style commands in tox and pre-commit configs

New Features:
- Integrate pydoclint into flake8-ignition-api hook with configuration in tox.ini and pre-commit

Enhancements:
- Replace bash-based sort-all invocation with a Python rglob script for file discovery
- Add unimport step before isort and configure isort to use tox.ini settings
- Specify python3.12 as base interpreter for the style environment

Build:
- Add pydoclint to tox style environment dependencies
- Include pydoclint as an additional dependency for the flake8-ignition-api pre-commit hook

CI:
- Update pre-commit autofix_commit_msg to 'stylw: apply auto fixes with pre-commit'